### PR TITLE
[Fix] Suppressed all unchecked casting warnings

### DIFF
--- a/src/main/java/duke/modules/TaskWithMultiplePeriods.java
+++ b/src/main/java/duke/modules/TaskWithMultiplePeriods.java
@@ -120,6 +120,7 @@ public abstract class TaskWithMultiplePeriods<E extends TimePeriod> extends Task
         return false;
     }
 
+    @SuppressWarnings("unchecked")
     public <T extends TaskWithMultiplePeriods> boolean isClashing(T other) {
         return this.isClashing(other.getPeriods());
     }

--- a/src/main/java/duke/util/argparse4j/action/Join.java
+++ b/src/main/java/duke/util/argparse4j/action/Join.java
@@ -8,6 +8,7 @@ import net.sourceforge.argparse4j.inf.ArgumentParser;
 public class Join implements ArgumentAction {
 
     @Override
+    @SuppressWarnings("unchecked")
     public void run(ArgumentParser parser, Argument arg, Map<String, Object> attrs, String flag, Object value) {
         if (value instanceof Iterable) {
             attrs.put(arg.getDest(), String.join(" ", (Iterable) value));


### PR DESCRIPTION
During compilation, gradle/java warned about some unsafe casting.

This is, however, a known problem. The compiler is complaining because it could not automatically infer the types of some variables due to heavy implementation of generics and abstraction in some parts of the code which were used to improve scalability and flexibility.

Regardless of the warnings, the casting is safe by design and should not break ModPlanner. Thus, I have added a fix to suppress these warnings.